### PR TITLE
moves postfix main config above aliases

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -231,43 +231,6 @@
         item.item.type == "sdbm")
       loop: '{{ postfix_transport_configuration.results }}'
 
-- name: check if inet_interfaces will change
-  ansible.builtin.lineinfile:
-    path: /etc/postfix/main.cf
-    regexp: '^inet_interfaces = '
-    line: 'inet_interfaces = {{ postfix_inet_interfaces | join(", ") }}'
-  check_mode: yes
-  register: postfix_inet_interfaces_precheck
-
-- name: set needs restart fact
-  ansible.builtin.set_fact:
-    postfix_needs_restart: '{{ postfix_inet_interfaces_precheck.changed }}'
-
-- name: configure main.cf
-  ansible.builtin.template:
-    src: '{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version }}-main.cf.j2'
-    dest: /etc/postfix/main.cf
-    owner: root
-    group: root
-    mode: 0644
-  register: postfix_main_configuration
-
-- name: reload postfix service
-  ansible.builtin.service:
-    name: postfix
-    state: reloaded
-  when: >
-    postfix_main_configuration.changed and
-    not postfix_needs_restart
-
-- name: restart postfix service
-  ansible.builtin.service:
-    name: postfix
-    state: restarted
-  when: >
-    postfix_main_configuration.changed and
-    postfix_needs_restart
-
 - name: enable postfix service and assure it is started
   ansible.builtin.service:
     name: postfix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -19,6 +19,43 @@
     name: sendmail
     state: absent
 
+- name: check if inet_interfaces will change
+  ansible.builtin.lineinfile:
+    path: /etc/postfix/main.cf
+    regexp: '^inet_interfaces = '
+    line: 'inet_interfaces = {{ postfix_inet_interfaces | join(", ") }}'
+  check_mode: yes
+  register: postfix_inet_interfaces_precheck
+
+- name: set needs restart fact
+  ansible.builtin.set_fact:
+    postfix_needs_restart: '{{ postfix_inet_interfaces_precheck.changed }}'
+
+- name: configure main.cf
+  ansible.builtin.template:
+    src: '{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version }}-main.cf.j2'
+    dest: /etc/postfix/main.cf
+    owner: root
+    group: root
+    mode: 0644
+  register: postfix_main_configuration
+
+- name: reload postfix service
+  ansible.builtin.service:
+    name: postfix
+    state: reloaded
+  when: >
+    postfix_main_configuration.changed and
+    not postfix_needs_restart
+
+- name: restart postfix service
+  ansible.builtin.service:
+    name: postfix
+    state: restarted
+  when: >
+    postfix_main_configuration.changed and
+    postfix_needs_restart
+
 - name: configure /etc/aliases
   ansible.builtin.template:
     src: '{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version }}-aliases.j2'


### PR DESCRIPTION
Is needed if you want to disable IPv6: The command `newaliases` will fail if IPv6 is stilled enabled in `main.cf` but your server doesn't support IPv6.

With this change the `main.cf` will be changed before the aliases are created. I can't tell if there will be complications in other situations/configurations.